### PR TITLE
Removed set isk to prevent overwriting current settings.

### DIFF
--- a/after/syntax/css/vim-coloresque.vim
+++ b/after/syntax/css/vim-coloresque.vim
@@ -122,9 +122,6 @@ function! s:VimCssInit(update)
     if a:update==1
         call s:ClearMatches()
     endif
-    :set isk+=-
-    :set isk+=#
-    :set isk+=.
 
     if len(keys(b:color_pattern))>0
         call s:RestoreColors()


### PR DESCRIPTION
Setting isk is a personal preference and should be configured .vimrc and not globally by a plugin.
