### PR TITLE
Make color matches not happen in the middle of \w

### DIFF
--- a/after/syntax/css/vim-coloresque.vim
+++ b/after/syntax/css/vim-coloresque.vim
@@ -70,7 +70,7 @@ function! s:MatchColorValue(color, part)
   if !exists('b:matchescache')
     let b:matchescache = {}
   elseif !exists('b:matchescache[a:part]')
-    let b:matchescache[a:part] = matchadd(group, a:part, -1)
+    let b:matchescache[a:part] = matchadd(group, '\w\@<!'.a:part, -1)
   endif
 
   "call add(w:matchescache, matchadd(group, a:part, -1))
@@ -316,9 +316,9 @@ function! s:PreviewCSSColor(str)
 
   let line=a:str "getline(a:w)
   let colorexps = {
-    \ 'hex'  : '#[0-9A-Fa-f]\{3\}\>\|#[0-9A-Fa-f]\{6\}\>',
-    \ 'rgba' : 'rgba\?(\s*\(\d\{1,3}%\?\)\s*,\s*\(\d\{1,3}%\?\)\s*,\s*\(\d\{1,3}%\?\)\s*\%(,[^)]*\)\?)',
-    \ 'hsla' : 'hsla\?(\s*\(\d\{1,3}%\?\)\s*,\s*\(\d\{1,3}%\?\)\s*,\s*\(\d\{1,3}%\?\)\s*\%(,[^)]*\)\?)'
+    \ 'hex'  : '\w\@<!#[0-9A-Fa-f]\{3\}\>\|#[0-9A-Fa-f]\{6\}\>',
+    \ 'rgba' : '\w\@<!rgba\?(\s*\(\d\{1,3}%\?\)\s*,\s*\(\d\{1,3}%\?\)\s*,\s*\(\d\{1,3}%\?\)\s*\%(,[^)]*\)\?)',
+    \ 'hsla' : '\w\@<!hsla\?(\s*\(\d\{1,3}%\?\)\s*,\s*\(\d\{1,3}%\?\)\s*,\s*\(\d\{1,3}%\?\)\s*\%(,[^)]*\)\?)'
     \ }
     "\ 'color': w:colorDictRegExp
 


### PR DESCRIPTION
This PR fixes #40 nicely.

Valid colors won't appear inside of a word, so we'll use a clever bit of
vim to match them only not immediately after a word (as opposed to a
WORD, they're not the same thing in vim.) This was done by patching the
patterns in about line 319-321.

This created a new problem however if an invalid color such as…

call minpac#add('gko/vim-coloresque')

…happened to appear in the same file as a valid '#add' color. To fix
that, we use the same '\w\@<!' trick on b:matchescache. Issue fixed.

Thanks to markzen for suggesting the regex solution, I'd never have
stumbled upon it myself without a pointer in the right direction.