### PR TITLE
fix b:color_pattern not found error

### DIFF
--- a/after/syntax/css/vim-coloresque.vim
+++ b/after/syntax/css/vim-coloresque.vim
@@ -126,6 +126,12 @@ function! s:VimCssInit(update)
     :set isk+=#
     :set isk+=.
 
+    if !exists("b:color_pattern")
+        let b:color_pattern = {}
+        return
+    endif
+
+
     if len(keys(b:color_pattern))>0
         call s:RestoreColors()
         return


### PR DESCRIPTION
known issue mentioned in the issue but have not been merged which complains b:color_pattern is not defined.