### PR TITLE
Fixed issue #36 where colors will not display in color-capable terminals

### DIFF
--- a/after/syntax/css/vim-coloresque.vim
+++ b/after/syntax/css/vim-coloresque.vim
@@ -386,7 +386,7 @@ if has('gui_running') || &t_Co==256
     endfor
   endif
 
-  if ! has('gui_running')
+  if ! has('gui_running') && &termguicolors == 0
 
     let s:black = 0
     let s:white = 15

--- a/after/syntax/css/vim-coloresque.vim
+++ b/after/syntax/css/vim-coloresque.vim
@@ -386,7 +386,7 @@ if has('gui_running') || &t_Co==256
     endfor
   endif
 
-  if ! has('gui_running') && &termguicolors == 0
+  if !has('gui_running') && !has('termguicolors')
 
     let s:black = 0
     let s:white = 15


### PR DESCRIPTION
Before that, colors won't display in alacritty – a terminal capable of displaying full 8-bit-per-channel color.