### PR TITLE
Fix heading markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ The issue [#13](https://github.com/gorodinskiy/vim-coloresque/issues/13) from 26
 
 color preview for vim.
 
-###Overview
+### Overview
 
 This is merge of [ap vim-css-color](https://github.com/ap/vim-css-color) and [colorizer](https://github.com/lilydjwg/colorizer).
 The main goal was to fix cursorline [bug](https://github.com/skammer/vim-css-color/issues/12) and keep named colors(i.e. white, black, aqua). I ended up mixing both plugins plus wrote some stuff, so I decided to leave it as a separate plugin.
 
-###Installation
+### Installation
 
 Via [vundle](https://github.com/gmarik/vundle):
 
@@ -26,7 +26,7 @@ Via [vundle](https://github.com/gmarik/vundle):
 Bundle 'https://github.com/gorodinskiy/vim-coloresque.git'
 ```
 
-###Features
+### Features
 
 You can still use hsl(a)
 


### PR DESCRIPTION
Github's markdown parser now enforces space between the hashes and the first character.